### PR TITLE
meeting: change meeting occurrence ID type to string

### DIFF
--- a/meeting.go
+++ b/meeting.go
@@ -151,7 +151,7 @@ type (
 
 	// Occurrence is an occurrence object
 	Occurrence struct {
-		ID        int    `json:"occurrence_id"`
+		ID        string `json:"occurrence_id"`
 		StartTime *Time  `json:"start_time"`
 		Duration  int    `json:"duration"`
 		Status    string `json:"status"`


### PR DESCRIPTION
Change the type for Occurences ID to string. A JSON unmarshaling error
is encountered when one attempts the GetMeeting function.

https://github.com/zoom-lib-golang/zoom-lib-golang/issues/26