### PR TITLE
Change pmi value type from int64 to string  from meeting struct as per zoom meeting response change.

### DIFF
--- a/meeting.go
+++ b/meeting.go
@@ -136,7 +136,7 @@ type (
 		EncryptedPassword string        `json:"encrypted_password"`
 		// PMI is Personal Meeting ID. Only used for scheduled meetings and recurring meetings with
 		// no fixed time
-		PMI            int64           `json:"pmi"`
+		PMI            string          `json:"pmi"`
 		TrackingFields []TrackingField `json:"tracking_fields"`
 		Occurrences    []Occurrence    `json:"occurrences"`
 		Settings       MeetingSettings `json:"settings"`


### PR DESCRIPTION
Hello, When using the Zoom Create Meeting API, the response returns the PMI value as a string type. However, in the Zoom-lib-golang library, it is an int64 type. As a result, when unmarshaling the response, an error occurs.
```
json: cannot unmarshal string into Go struct field Meeting.pmi of type int64 
```
This pull request includes a change to the meeting struct's PMI value, which has been updated from int64 to string.

Zoom response :- [https://marketplace.zoom.us/docs/api-reference/zoom-api/methods/#operation/meetingCreate](url)