### PR TITLE
Add oauth2 server to server support

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,37 @@
+package zoom
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func (c *Client) addRequestAuth(req *http.Request, err error) (*http.Request, error) {
+	if err != nil {
+		return nil, err
+	}
+
+	var token string
+	switch c.AuthStrategy {
+	case JWTAuth:
+		token, err = jwtToken(c.Key, c.Secret)
+		if err != nil {
+			return nil, fmt.Errorf("failed to configure jwt token: %w", err)
+		}
+
+	case ServerToServerOAuth2:
+		token, err = c.oauth2Handler.Authorize()
+		if err != nil {
+			return nil, fmt.Errorf("failed to set up server-to-server oauth2 token: %w", err)
+		}
+	}
+
+	if Debug {
+		log.Println("Auth Token: " + token + " with auth strategy: " + string(c.AuthStrategy))
+	}
+
+	// set Authorization header
+	req.Header.Add("Authorization", "Bearer "+token)
+
+	return req, nil
+}

--- a/jwt.go
+++ b/jwt.go
@@ -1,8 +1,6 @@
 package zoom
 
 import (
-	"log"
-	"net/http"
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
@@ -17,25 +15,4 @@ func jwtToken(key string, secret string) (string, error) {
 	token.Header["alg"] = "HS256"
 	token.Header["typ"] = "JWT"
 	return token.SignedString([]byte(secret))
-}
-
-func (c *Client) addRequestAuth(req *http.Request, err error) (*http.Request, error) {
-	if err != nil {
-		return nil, err
-	}
-
-	// establish JWT token
-	ss, err := jwtToken(c.Key, c.Secret)
-	if err != nil {
-		return nil, err
-	}
-
-	if Debug {
-		log.Println("JWT Token: " + ss)
-	}
-
-	// set JWT Authorization header
-	req.Header.Add("Authorization", "Bearer "+ss)
-
-	return req, nil
 }

--- a/oauth2.go
+++ b/oauth2.go
@@ -1,0 +1,105 @@
+package zoom
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const zoomOAuth2TokenURL = "https://zoom.us/oauth/token"
+
+type oauth2Handler struct {
+	token *oauth2Token
+
+	oauthAccountID    string
+	oauthClientID     string
+	oauthClientSecret string
+}
+
+type oauth2Token struct {
+	Token     string
+	ExpiresAt time.Time
+}
+
+func (t oauth2Token) isValid() bool {
+	if t.Token == "" { // Empty token is always invalid
+		return false
+	}
+
+	return time.Now().Before(t.ExpiresAt)
+}
+
+type zoomReply struct {
+	AccessToken      string `json:"access_token"`
+	ExpiresInSeconds int    `json:"expires_in"`
+}
+
+func (o *oauth2Handler) Authorize() (string, error) {
+
+	if o.token != nil && o.token.isValid() {
+		return o.token.Token, nil // reuse tokens while they are valid
+	}
+
+	uri, err := url.Parse(zoomOAuth2TokenURL)
+	if err != nil {
+		return "", fmt.Errorf("could not parse URL %s to authorize oauth2: %w", zoomOAuth2TokenURL, err)
+	}
+
+	q := uri.Query()
+	q.Add("grant_type", "account_credentials")
+	q.Add("account_id", o.oauthAccountID)
+	uri.RawQuery = q.Encode()
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, uri.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("could not create request to authorize OAuth2: %w", err)
+	}
+	req.SetBasicAuth(o.oauthClientID, o.oauthClientSecret)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute request to authorize oauth2 server-to-server token: %w", err)
+	}
+
+	b, err := io.ReadAll(response.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read body when authorizing oauth2 server-to-server token: %w", err)
+	}
+
+	switch response.StatusCode {
+	case http.StatusOK:
+
+		if Debug {
+			log.Printf("Got json reply: %s\n", string(b))
+		}
+
+		reply := zoomReply{}
+		if err := json.Unmarshal(b, &reply); err != nil {
+			return "", fmt.Errorf("failed to unmarshal json body when authorizing oauth2 server-to-server token: %w", err)
+		}
+
+		if reply.AccessToken == "" {
+			return "", fmt.Errorf("json reply when authorizing oauth2 server-to-server returned an empty access token: %s", string(b))
+		}
+
+		o.token = &oauth2Token{
+			Token:     reply.AccessToken,
+			ExpiresAt: time.Now().Add(time.Duration(reply.ExpiresInSeconds) * time.Second),
+		}
+
+		return o.token.Token, nil
+
+	default:
+		return "", fmt.Errorf("failed to authorize oauth2 server-to-server token, got status code %d with body %s on request %+v", response.StatusCode, string(b), req)
+	}
+
+}


### PR DESCRIPTION
Hey, I added oauth2 server to server support.

I've used [zoom-recording-downloader](https://github.com/ricardorodrigues-ca/zoom-recording-downloader/) as an inspiration for how to implement it, which prevented having to add dependencies to other libraries like oauth2.

I did not add any tests initially, and I added a separate function to create an oauth2 client without impacting the previous implementation with jwt tokens.